### PR TITLE
Avoid warnings in examples / add documentation (CPAN Pull Request Challenge)

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,4 @@
+    * Tested against Google Chrome 67.0.3396.99  Built on OSX, thanks Travis CI
     * Tested against Chrome/67.0.3396.99 / Win64, thanks AppVeyor
     * Tested against Chrome Chrome/59.0.3071.115
     * Tested against Chromium HeadlessChrome/60.0.3110.0

--- a/Changes
+++ b/Changes
@@ -1,4 +1,3 @@
-    * Tested against Google Chrome 67.0.3396.99  Built on OSX, thanks Travis CI
     * Tested against Chrome/67.0.3396.99 / Win64, thanks AppVeyor
     * Tested against Chrome Chrome/59.0.3071.115
     * Tested against Chromium HeadlessChrome/60.0.3110.0

--- a/MANIFEST
+++ b/MANIFEST
@@ -1,5 +1,4 @@
 .gitignore
-50-mech-redirect.t
 Changes
 examples/dump-links.pl
 examples/gen_examples_pod.pl
@@ -55,6 +54,7 @@ t/50-mech-get-nonexistent.t
 t/50-mech-get.t
 t/50-mech-new-dsl.t
 t/50-mech-new.t
+t/50-mech-redirect.t
 t/50-mech-start-url.t
 t/50-mech-status.t
 t/50-popup.t

--- a/examples/README
+++ b/examples/README
@@ -8,6 +8,7 @@ Getting started
 url-to-image.pl                 Take a screenshot of a website
 html-to-pdf.pl                  Convert HTML to PDF
 dump-links.pl                   Dump links on a webpage
+sendkeys.pl                     Send keystrokes to a page
 
 Javascript
 ==========

--- a/examples/dump-links.pl
+++ b/examples/dump-links.pl
@@ -1,4 +1,5 @@
 use strict;
+use Log::Log4perl qw(:easy);
 use WWW::Mechanize::Chrome;
 
 my $mech = WWW::Mechanize::Chrome->new();
@@ -16,11 +17,15 @@ dump-links.pl - Dump links on a webpage
 
 =head1 SYNOPSIS
 
-dump-links.pl
+From the examples directory:
+
+  perl dump-links.pl
 
 =head1 DESCRIPTION
 
-This program demonstrates how to read elements out of the Chrome
-DOM and how to get at text within nodes.
+This program demonstrates how to read elements out of the Chrome DOM
+and how to get at text within nodes.  It prints links with the CSS
+class "download" from a file provided with the distribution.
+
 
 =cut

--- a/examples/html-to-pdf.pl
+++ b/examples/html-to-pdf.pl
@@ -1,18 +1,33 @@
 #!perl -w
 use strict;
+use Log::Log4perl qw(:easy);
 use WWW::Mechanize::Chrome;
+
+my $url = shift @ARGV
+    or  die "Usage: perl $0 <url>\n";
 
 my $mech = WWW::Mechanize::Chrome->new(
     headless => 1, # otherwise, PDF printing will not work
 );
 
-for my $url (@ARGV) {
-    print "Loading $url";
-    $mech->get($url);
+print "Loading $url";
+$mech->get($url);
 
-    my $fn= 'screen.pdf';
-    my $page_pdf = $mech->content_as_pdf(
-        filename => $fn,
-    );
-    print "\nSaved $url as $fn\n";
-};
+my $fn= 'screen.pdf';
+my $page_pdf = $mech->content_as_pdf(
+    filename => $fn,
+);
+print "\nSaved $url as $fn\n";
+
+=head1 NAME
+
+html-to-pdf.pl
+
+=head1 SYNOPSIS
+
+   perl html-to-pdf.pl https://www.perl.org/
+
+=head1 DESCRIPTION
+
+This example takes an URL from the command line, renders it and and
+saves it as a PDF file in the current directory.

--- a/examples/javascript.pl
+++ b/examples/javascript.pl
@@ -1,5 +1,6 @@
 #!perl -w
 use strict;
+use Log::Log4perl qw(:easy);
 use WWW::Mechanize::Chrome;
 
 my $mech = WWW::Mechanize::Chrome->new();
@@ -17,7 +18,7 @@ javascript.pl - execute Javascript in a page
 
 =head1 SYNOPSIS
 
-javascript.pl
+  perl javascript.pl
 
 =head1 DESCRIPTION
 

--- a/examples/links.html
+++ b/examples/links.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<title>links.html</title>
+</head>
+<body>
+<h1>N&uuml;tzliche Links</h1>
+<ul>
+<li><a href="http://frankfurt.pm">Frankfurt Perl Mongers</a></li>
+<li><a href="https://perlmonks.org">PerlMonks</a></li>
+<li><a class="download" href="https://github.com/Corion/WWW-Mechanize-Chrome.git">WWW::Mechanize::Chrome repository</a></li>
+<li><a href="http://search.cpan.org">CPAN</a></li>
+</ul>
+</body>
+</html>

--- a/examples/sendkeys.pl
+++ b/examples/sendkeys.pl
@@ -1,5 +1,6 @@
 #!perl -w
 use strict;
+use Log::Log4perl qw(:easy);
 use WWW::Mechanize::Chrome;
 
 my $mech = WWW::Mechanize::Chrome->new();
@@ -16,7 +17,7 @@ sendkeys.pl - send keystrokes to a page
 
 =head1 SYNOPSIS
 
-    sendkeys.pl
+    perl sendkeys.pl
 
 =head1 DESCRIPTION
 

--- a/examples/url-to-image.pl
+++ b/examples/url-to-image.pl
@@ -1,6 +1,7 @@
 use strict;
 use File::Spec;
 use File::Basename 'dirname';
+use Log::Log4perl qw(:easy);
 use WWW::Mechanize::Chrome;
 
 my $mech = WWW::Mechanize::Chrome->new();
@@ -21,3 +22,16 @@ sub show_screen() {
 $mech->get('http://act.yapc.eu/gpw2017');
 
 show_screen;
+
+=head1 NAME
+
+url-to-image.pl
+
+=head1 SYNOPSIS
+
+  perl url-to-image.pl
+
+=head1 DESCRIPTION
+
+This example fetches a web page and creates a screenshot in PNG format
+in the script's directory.

--- a/lib/WWW/Mechanize/Chrome/Examples.pm
+++ b/lib/WWW/Mechanize/Chrome/Examples.pm
@@ -37,7 +37,7 @@ program that is also included in the examples directory.
 
 =head1 Example programs
 
-The following is a list of the 4 example programs that are included in the WWW::Mechanize::Chrome distribution.
+The following is a list of the 5 example programs that are included in the WWW::Mechanize::Chrome distribution.
 
 =over
 
@@ -46,6 +46,8 @@ The following is a list of the 4 example programs that are included in the WWW::
 =item * L<Example: html-to-pdf.pl> Convert HTML to PDF
 
 =item * L<Example: dump-links.pl> Dump links on a webpage
+
+=item * L<Example: sendkeys.pl> Send keystrokes to a page
 
 =item * L<Example: javascript.pl> Execute Javascript in the webpage context
 
@@ -56,6 +58,7 @@ The following is a list of the 4 example programs that are included in the WWW::
     use strict;
     use File::Spec;
     use File::Basename 'dirname';
+    use Log::Log4perl qw(:easy);
     use WWW::Mechanize::Chrome;
     
     my $mech = WWW::Mechanize::Chrome->new();
@@ -76,6 +79,19 @@ The following is a list of the 4 example programs that are included in the WWW::
     $mech->get('http://act.yapc.eu/gpw2017');
     
     show_screen;
+    
+    =head1 NAME
+    
+    url-to-image.pl
+    
+    =head1 SYNOPSIS
+    
+      perl url-to-image.pl
+    
+    =head1 DESCRIPTION
+    
+    This example fetches a web page and creates a screenshot in PNG format
+    in the script's directory.
 
 
 Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chrome-0.24/examples/url-to-image.pl>
@@ -84,28 +100,45 @@ Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chr
 
     #!perl -w
     use strict;
+    use Log::Log4perl qw(:easy);
     use WWW::Mechanize::Chrome;
+    
+    my $url = shift @ARGV
+        or  die "Usage: perl $0 <url>\n";
     
     my $mech = WWW::Mechanize::Chrome->new(
         headless => 1, # otherwise, PDF printing will not work
     );
     
-    for my $url (@ARGV) {
-        print "Loading $url";
-        $mech->get($url);
+    print "Loading $url";
+    $mech->get($url);
     
-        my $fn= 'screen.pdf';
-        my $page_pdf = $mech->content_as_pdf(
-            filename => $fn,
-        );
-        print "\nSaved $url as $fn\n";
-    };
+    my $fn= 'screen.pdf';
+    my $page_pdf = $mech->content_as_pdf(
+        filename => $fn,
+    );
+    print "\nSaved $url as $fn\n";
+    
+    =head1 NAME
+    
+    html-to-pdf.pl
+    
+    =head1 SYNOPSIS
+    
+       perl html-to-pdf.pl https://www.perl.org/
+    
+    =head1 DESCRIPTION
+    
+    This example takes an URL from the command line, renders it and and
+    saves it as a PDF file in the current directory.
+
 
 Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chrome-0.24/examples/html-to-pdf.pl>
 
 =head2 Example: dump-links.pl
 
     use strict;
+    use Log::Log4perl qw(:easy);
     use WWW::Mechanize::Chrome;
     
     my $mech = WWW::Mechanize::Chrome->new();
@@ -123,21 +156,60 @@ Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chr
     
     =head1 SYNOPSIS
     
-    dump-links.pl
+    From the examples directory:
+    
+      perl dump-links.pl
     
     =head1 DESCRIPTION
     
-    This program demonstrates how to read elements out of the Chrome
-    DOM and how to get at text within nodes.
+    This program demonstrates how to read elements out of the Chrome DOM
+    and how to get at text within nodes.  It prints links with the CSS
+    class "download" from a file provided with the distribution.
+    
     
     =cut
 
+
 Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chrome-0.24/examples/dump-links.pl>
+
+=head2 Example: sendkeys.pl
+
+    #!perl -w
+    use strict;
+    use Log::Log4perl qw(:easy);
+    use WWW::Mechanize::Chrome;
+    
+    my $mech = WWW::Mechanize::Chrome->new();
+    
+    $mech->get( 'https://google.com' );
+    
+    $mech->sendkeys( string => "test\r" );
+    
+    $mech->sleep( 10 );
+    
+    =head1 NAME
+    
+    sendkeys.pl - send keystrokes to a page
+    
+    =head1 SYNOPSIS
+    
+        perl sendkeys.pl
+    
+    =head1 DESCRIPTION
+    
+    B<This program> demonstrates how to type some input into a text field
+    and then press the C<enter> key.
+    
+    =cut
+
+
+Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chrome-0.24/examples/sendkeys.pl>
 
 =head2 Example: javascript.pl
 
     #!perl -w
     use strict;
+    use Log::Log4perl qw(:easy);
     use WWW::Mechanize::Chrome;
     
     my $mech = WWW::Mechanize::Chrome->new();
@@ -155,7 +227,7 @@ Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chr
     
     =head1 SYNOPSIS
     
-    javascript.pl
+      perl javascript.pl
     
     =head1 DESCRIPTION
     
@@ -163,6 +235,7 @@ Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chr
     Javascript in a page.
     
     =cut
+
 
 Download this example: L<http://cpansearch.perl.org/src/CORION/WWW-Mechanize-Chrome-0.24/examples/javascript.pl>
 

--- a/t/50-mech-redirect.t
+++ b/t/50-mech-redirect.t
@@ -4,7 +4,7 @@ use Test::More;
 use Log::Log4perl qw(:easy);
 
 use WWW::Mechanize::Chrome;
-use lib './inc', '../inc';
+use lib '.';
 use Test::HTTP::LocalServer;
 #use Mojolicious;
 
@@ -35,7 +35,7 @@ my $server = Test::HTTP::LocalServer->spawn(
     #debug => 1,
 );
 
-t::helper::run_across_instances(\@instances, $instance_port, \&new_mech, 6, sub {
+t::helper::run_across_instances(\@instances, \&new_mech, 6, sub {
     my ($browser_instance, $mech) = @_;
 
     isa_ok $mech, 'WWW::Mechanize::Chrome';


### PR DESCRIPTION
Here are some suggested changes, mostly for the examples:

- Avoid warning of uninitialized Log4Perl by adding including 'easy'
- Added name, synopsis and description where it was missing
- Added sendkeys to README
- html-to-pdf.pl: Instead of the loop over ARGV, process only one file.  Two reasons: 1) output went to the same file anyway, overwriting previous renderings, and 2) with the pure-perl event loop, the second request hangs infinitely - seems that there's no event happening.  With EV all is fine.
- A data file links.html was added (needed by dump-links.pl)
- Not related to the examples: A test file was moved from the root directory to /t, with some changes I received per Mail.

I've re-generated Examples.pm but not yet made changes to the Changes file.
