### PR TITLE
ExtUtils::MakeMaker minimal version

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,7 +40,7 @@ my %module = (
 
     PL_FILES            => {},
     BUILD_REQUIRES => {
-        'ExtUtils::MakeMaker' => '6.64',
+        'ExtUtils::MakeMaker' => '5.52_01',
     },
 
     PREREQ_PM => {

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -40,7 +40,7 @@ my %module = (
 
     PL_FILES            => {},
     BUILD_REQUIRES => {
-        'ExtUtils::MakeMaker' => 0,
+        'ExtUtils::MakeMaker' => '6.64',
     },
 
     PREREQ_PM => {


### PR DESCRIPTION
i put 'ExtUtils::MakeMaker' => '6.64' because i see you use TEST_REQUIRE section and in the docs I read: that is available in version 6.64 and above.