### PR TITLE
Close Chrome with SIGTERM rather than SIGKILL

### DIFF
--- a/lib/WWW/Mechanize/Chrome.pm
+++ b/lib/WWW/Mechanize/Chrome.pm
@@ -855,7 +855,7 @@ sub _connect( $self, %options ) {
     if ( $err ) {
         if( $self->{ kill_pid } and my $pid = delete $self->{ pid }) {
             local $SIG{CHLD} = 'IGNORE';
-            kill 'SIGKILL' => $pid;
+            kill 'SIGTERM' => $pid;
             waitpid $pid, 0;
         };
         croak $err;
@@ -1478,7 +1478,7 @@ sub DESTROY {
 
     if( $pid ) {
         local $SIG{CHLD} = 'IGNORE';
-        kill 'SIGKILL' => $pid;
+        kill 'SIGTERM' => $pid;
         waitpid $pid, 0;
     };
     %{ $_[0] }= (); # clean out all other held references


### PR DESCRIPTION
Stopping Chrome processes launched by WMC using `SIGKILL` is quite extreme: Chrome responds to `SIGTERM`, which has the added benefit of giving Chrome a chance to save its state and exit cleanly. There are also situations where sending `SIGKILL` causes quite a mess: I'm driving a copy of Chrome with extensions installed ([thus preventing me from using headless mode](https://bugs.chromium.org/p/chromium/issues/detail?id=706008)), so I've written a small wrapper script that starts an Xvfb followed by Chrome, and also traps various exit signals and relays them to Xvfb and Chrome so everything gets cleaned up correctly. I then launch the wrapper script using WMC. When the WMC object gets destroyed, sending `SIGKILL` to my wrapper script causes both Xvfb and Chrome to be orphaned and adopted by init, preventing WMC from working again until Chrome is killed manually (because the old Chrome process is still listening on port 9222), not to mention consuming large amounts of resources in the meantime.

This PR changes WMC so that it sends `SIGTERM` to close Chrome rather than `SIGKILL`. It ought to be sensible for most use cases, since Chrome has rarely (if ever) failed to respond to `SIGTERM` in my experience. If this isn't preferable for any reason, it'd still be nice to be able to make the signal configurable (e.g. in the WMC constructor).