### PR TITLE
Restores ability of Chrome::DevToolsProtocol to connect to an existing chrome

### DIFF
--- a/lib/Chrome/DevToolsProtocol.pm
+++ b/lib/Chrome/DevToolsProtocol.pm
@@ -551,6 +551,7 @@ sub build_url( $self, %options ) {
         $url = URI->new('json', 'http');
         $url->port( $self->port );
         $url->host( $self->host );
+	$url->scheme('http');
         $url = "$url";
     };
     $url .= '/' . $options{domain} if $options{ domain };


### PR DESCRIPTION
The URL formed by Chrome::DevToolsProtocol::build_url seems to be broken when trying to build from an existing host and port, as it lacks the `http` scheme.  Bug appears to have been introduced at 6e1f2d6fc4797b9698fff6626fffb5601a575da1.