### PR TITLE
Bugfix: Encode the body on getting it

### DIFF
--- a/lib/WWW/Mechanize/Chrome.pm
+++ b/lib/WWW/Mechanize/Chrome.pm
@@ -2515,7 +2515,7 @@ sub httpResponseFromChromeResponse( $self, $res ) {
         weaken $s;
         $full_response_future = $self->getResponseBody( $requestId )->then( sub( $body ) {
             $s->log('debug', "Response body arrived");
-            $response->content( $body );
+            $response->content( encode_json( $body ) );
             #undef $full_response_future;
             Future->done($body)
         })->retain;


### PR DESCRIPTION
On setting the response body to the response, the following error occurred: `HTTP::Message content must be bytes`