### PR TITLE
Handle being given the PID for the main process

### DIFF
--- a/lib/WWW/Mechanize/Chrome.pm
+++ b/lib/WWW/Mechanize/Chrome.pm
@@ -880,6 +880,10 @@ sub read_devtools_url( $self, $fh, $lines = 50 ) {
     my $devtools_url;
 
     my %pids;
+    for my $pid ($self->{pid}->@*) {
+        $pids{ $pid }++;
+    }
+
     while( $lines-- and ! defined $devtools_url and ! eof($fh)) {
         my $line = <$fh>;
         last unless defined $line;


### PR DESCRIPTION
Using the sbuild environment in Debian, the t/50-mech-autoclose.t test fails because pids has two PIDs in it, the parent PID twice. When I enable tracing I get this:

```
  2025/12/12 23:39:45 Spawned child as 2408, communicating via websocket
  2025/12/12 23:39:45 [[[2408:2440:1212/233945.236977:ERROR:dbus/bus.cc:406] Failed to connect to the bus: Failed to connect to socket /run/dbus/system_bus_socket: No such file or directory]]
  2025/12/12 23:39:45 Found a pid as '2408', original pid is 2408
```

And when printing out the contents of pids:

```
  $VAR1 = [
    2408,
    2408
  ];
```

Let's skip the main PID when looking for new PIDs.